### PR TITLE
remove only the indices, not the square brackets

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -41,8 +41,8 @@ internals.stringify = function (obj, prefix, options) {
         var key = objKeys[i];
         if (!options.indices &&
             Array.isArray(obj)) {
-
-            values = values.concat(internals.stringify(obj[key], prefix, options));
+            // values = values.concat(internals.stringify(obj[key], prefix + '[]', options));
+            values = values.concat(internals.stringify(obj[key], prefix + '[]', options));
         }
         else {
             values = values.concat(internals.stringify(obj[key], prefix + '[' + key + ']', options));

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -41,7 +41,6 @@ internals.stringify = function (obj, prefix, options) {
         var key = objKeys[i];
         if (!options.indices &&
             Array.isArray(obj)) {
-            // values = values.concat(internals.stringify(obj[key], prefix + '[]', options));
             values = values.concat(internals.stringify(obj[key], prefix + '[]', options));
         }
         else {

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -43,8 +43,7 @@ describe('stringify()', function () {
     });
 
     it('omits array indices when asked', function (done) {
-
-        expect(Qs.stringify({ a: ['b', 'c', 'd'] }, { indices: false })).to.equal('a=b&a=c&a=d');
+        expect(Qs.stringify({ a: ['b', 'c', 'd'] }, { indices: false })).to.equal('a%5B%5D=b&a%5B%5D=c&a%5B%5D=d');
         done();
     });
 
@@ -62,8 +61,7 @@ describe('stringify()', function () {
     });
 
     it('does not omit object keys when indices = false', function (done) {
-
-        expect(Qs.stringify({ a: [{ b: 'c' }] }, { indices: false })).to.equal('a%5Bb%5D=c');
+        expect(Qs.stringify({ a: [{ b: 'c' }] }, { indices: false })).to.equal('a%5B%5D%5Bb%5D=c');
         done();
     });
 


### PR DESCRIPTION
The `{indices: false}` feature isn't really doing what you would expect from the API. It's removing both the index number and the square brackets. This is a shame as the square brackets are expected to be there by a great many web technologies including PHP and Ruby On Rails. 