### PR TITLE
Fixed issue with recursion and passing strings into objects.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,7 +30,7 @@ exports.merge = function (target, source) {
         if (Array.isArray(target)) {
             target.push(source);
         }
-        else {
+        else if (typeof target !== 'object') {
             target[source] = true;
         }
 


### PR DESCRIPTION
I stumbled upon a bug in when using this merge method directly to merge two query param objects with each other containing only string values. 

e.g, target as {userId: "1234"} source as {userId: "64321"}.

This recursively caused the logic for passing strings into objects kick in as follows:
Target = "1234", Source = "64321".
"1234"["64321"] = true;

Hence the modified else clause to be sure that target is an object and not a string.

Regards
Per