### PR TITLE
Remove useless entry point.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/');

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.4.1",
   "description": "A querystring parser that supports nesting and arrays, with a depth limit",
   "homepage": "https://github.com/hapijs/qs",
-  "main": "index.js",
+  "main": "./lib/index.js",
   "dependencies": {},
   "devDependencies": {
     "code": "1.x.x",


### PR DESCRIPTION
This file is not needed to load the module. Just specify a main entry point in `package.json` and browserify/node will resolve the module automatically.