### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,5 @@
     "querystring",
     "qs"
   ],
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "http://github.com/hapijs/qs/raw/master/LICENSE"
-    }
-  ]
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/