### PR TITLE
make returning plain objects and allowing prototype overwriting properties optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ Qs.parse('a.hasOwnProperty=b', { plainObjects: true });
 // { a: { hasOwnProperty: 'b' } }
 ```
 
-By default parameters that would overwrite properties on the object prototype are ignored, if you wish to keep the data from those fields either use `plainObjects` as mentioned above, or set `prefixPrototypes` to `true` which will add an underscore `'_'` to the beginning of the key names to allow them to be returned:
+By default parameters that would overwrite properties on the object prototype are ignored, if you wish to keep the data from those fields either use `plainObjects` as mentioned above, or set `allowPrototypes` to `true` which will allow user input to overwrite those properties. *WARNING* It is generally a bad idea to enable this option as it can cause problems when attempting to use the properties that have been overwritten. Always be careful with this option.
 
 ```javascript
-Qs.parse('a.hasOwnProperty=b', { prefixPrototypes: true });
-// { a: { _hasOwnProperty: 'b' } }
+Qs.parse('a.hasOwnProperty=b', { allowPrototypes: true });
+// { a: { hasOwnProperty: 'b' } }
 ```
 
 URI encoded strings work too:

--- a/README.md
+++ b/README.md
@@ -34,11 +34,18 @@ For example, the string `'foo[bar]=baz'` converts to:
 }
 ```
 
-The parsed value is returned as a plain object, created via `Object.create(null)` and as such you should be aware that prototype methods do not exist on it and a user may set those names to whatever value they like:
+When using the `plainObjects` option the parsed value is returned as a plain object, created via `Object.create(null)` and as such you should be aware that prototype methods will not exist on it and a user may set those names to whatever value they like:
 
 ```javascript
-Qs.parse('a.hasOwnProperty=b');
+Qs.parse('a.hasOwnProperty=b', { plainObjects: true });
 // { a: { hasOwnProperty: 'b' } }
+```
+
+By default parameters that would overwrite properties on the object prototype are ignored, if you wish to keep the data from those fields either use `plainObjects` as mentioned above, or set `prefixPrototypes` to `true` which will add an underscore `'_'` to the beginning of the key names to allow them to be returned:
+
+```javascript
+Qs.parse('a.hasOwnProperty=b', { prefixPrototypes: true });
+// { a: { _hasOwnProperty: 'b' } }
 ```
 
 URI encoded strings work too:

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -10,7 +10,9 @@ var internals = {
     depth: 5,
     arrayLimit: 20,
     parameterLimit: 1000,
-    strictNullHandling: false
+    strictNullHandling: false,
+    plainObjects: false,
+    prefixPrototypes: false
 };
 
 
@@ -61,7 +63,7 @@ internals.parseObject = function (chain, val, options) {
         obj = obj.concat(internals.parseObject(chain, val, options));
     }
     else {
-        obj = Object.create(null);
+        obj = options.plainObjects ? Object.create(null) : {};
         var cleanRoot = root[0] === '[' && root[root.length - 1] === ']' ? root.slice(1, root.length - 1) : root;
         var index = parseInt(cleanRoot, 10);
         var indexString = '' + index;
@@ -109,6 +111,18 @@ internals.parseKeys = function (key, val, options) {
 
     var keys = [];
     if (segment[1]) {
+        // If we aren't using plain objects, optionally prefix keys
+        // that would overwrite object prototype properties
+        if (!options.plainObjects &&
+            Object.prototype.hasOwnProperty(segment[1])) {
+
+            if (!options.prefixPrototypes) {
+                return;
+            }
+
+            segment[1] = '_' + segment[1];
+        }
+
         keys.push(segment[1]);
     }
 
@@ -118,6 +132,15 @@ internals.parseKeys = function (key, val, options) {
     while ((segment = child.exec(key)) !== null && i < options.depth) {
 
         ++i;
+        if (!options.plainObjects &&
+            Object.prototype.hasOwnProperty(segment[1].replace(/\[|\]/g, ''))) {
+
+            if (!options.prefixPrototypes) {
+                continue;
+            }
+
+            segment[1] = segment[1].replace(/^\[/, '[_');
+        }
         keys.push(segment[1]);
     }
 
@@ -133,25 +156,26 @@ internals.parseKeys = function (key, val, options) {
 
 module.exports = function (str, options) {
 
-    if (str === '' ||
-        str === null ||
-        typeof str === 'undefined') {
-
-        return Object.create(null);
-    }
-
     options = options || {};
     options.delimiter = typeof options.delimiter === 'string' || Utils.isRegExp(options.delimiter) ? options.delimiter : internals.delimiter;
     options.depth = typeof options.depth === 'number' ? options.depth : internals.depth;
     options.arrayLimit = typeof options.arrayLimit === 'number' ? options.arrayLimit : internals.arrayLimit;
     options.parseArrays = options.parseArrays !== false;
     options.allowDots = options.allowDots !== false;
+    options.plainObjects = typeof options.plainObjects === 'boolean' ? options.plainObjects : internals.plainObjects;
+    options.prefixPrototypes = typeof options.prefixPrototypes === 'boolean' ? options.prefixPrototypes : internals.prefixPrototypes;
     options.parameterLimit = typeof options.parameterLimit === 'number' ? options.parameterLimit : internals.parameterLimit;
     options.strictNullHandling = typeof options.strictNullHandling === 'boolean' ? options.strictNullHandling : internals.strictNullHandling;
 
+    if (str === '' ||
+        str === null ||
+        typeof str === 'undefined') {
+
+        return options.plainObjects ? Object.create(null) : {};
+    }
 
     var tempObj = typeof str === 'string' ? internals.parseValues(str, options) : str;
-    var obj = Object.create(null);
+    var obj = options.plainObjects ? Object.create(null) : {};
 
     // Iterate over the keys and setup the new object
 
@@ -159,7 +183,7 @@ module.exports = function (str, options) {
     for (var i = 0, il = keys.length; i < il; ++i) {
         var key = keys[i];
         var newObj = internals.parseKeys(key, tempObj[key], options);
-        obj = Utils.merge(obj, newObj);
+        obj = Utils.merge(obj, newObj, options);
     }
 
     return Utils.compact(obj);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -12,7 +12,7 @@ var internals = {
     parameterLimit: 1000,
     strictNullHandling: false,
     plainObjects: false,
-    prefixPrototypes: false
+    allowPrototypes: false
 };
 
 
@@ -116,11 +116,9 @@ internals.parseKeys = function (key, val, options) {
         if (!options.plainObjects &&
             Object.prototype.hasOwnProperty(segment[1])) {
 
-            if (!options.prefixPrototypes) {
+            if (!options.allowPrototypes) {
                 return;
             }
-
-            segment[1] = '_' + segment[1];
         }
 
         keys.push(segment[1]);
@@ -135,11 +133,9 @@ internals.parseKeys = function (key, val, options) {
         if (!options.plainObjects &&
             Object.prototype.hasOwnProperty(segment[1].replace(/\[|\]/g, ''))) {
 
-            if (!options.prefixPrototypes) {
+            if (!options.allowPrototypes) {
                 continue;
             }
-
-            segment[1] = segment[1].replace(/^\[/, '[_');
         }
         keys.push(segment[1]);
     }
@@ -163,7 +159,7 @@ module.exports = function (str, options) {
     options.parseArrays = options.parseArrays !== false;
     options.allowDots = options.allowDots !== false;
     options.plainObjects = typeof options.plainObjects === 'boolean' ? options.plainObjects : internals.plainObjects;
-    options.prefixPrototypes = typeof options.prefixPrototypes === 'boolean' ? options.prefixPrototypes : internals.prefixPrototypes;
+    options.allowPrototypes = typeof options.allowPrototypes === 'boolean' ? options.allowPrototypes : internals.allowPrototypes;
     options.parameterLimit = typeof options.parameterLimit === 'number' ? options.parameterLimit : internals.parameterLimit;
     options.strictNullHandling = typeof options.strictNullHandling === 'boolean' ? options.strictNullHandling : internals.strictNullHandling;
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -60,7 +60,7 @@ exports.merge = function (target, source, options) {
         var key = keys[k];
         var value = source[key];
 
-        if (!target[key]) {
+        if (!Object.prototype.hasOwnProperty.call(target, key)) {
             target[key] = value;
         }
         else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,14 +5,14 @@
 
 var internals = {};
 internals.hexTable = new Array(256);
-for (var i = 0; i < 256; ++i) {
-    internals.hexTable[i] = '%' + ((i < 16 ? '0' : '') + i.toString(16)).toUpperCase();
+for (var h = 0; h < 256; ++h) {
+    internals.hexTable[h] = '%' + ((h < 16 ? '0' : '') + h.toString(16)).toUpperCase();
 }
 
 
-exports.arrayToObject = function (source) {
+exports.arrayToObject = function (source, options) {
 
-    var obj = Object.create(null);
+    var obj = options.plainObjects ? Object.create(null) : {};
     for (var i = 0, il = source.length; i < il; ++i) {
         if (typeof source[i] !== 'undefined') {
 
@@ -24,7 +24,7 @@ exports.arrayToObject = function (source) {
 };
 
 
-exports.merge = function (target, source) {
+exports.merge = function (target, source, options) {
 
     if (!source) {
         return target;
@@ -52,7 +52,7 @@ exports.merge = function (target, source) {
     if (Array.isArray(target) &&
         !Array.isArray(source)) {
 
-        target = exports.arrayToObject(target);
+        target = exports.arrayToObject(target, options);
     }
 
     var keys = Object.keys(source);
@@ -64,7 +64,7 @@ exports.merge = function (target, source) {
             target[key] = value;
         }
         else {
-            target[key] = exports.merge(target[key], value);
+            target[key] = exports.merge(target[key], value, options);
         }
     }
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -23,194 +23,194 @@ describe('parse()', function () {
 
     it('parses a simple string', function (done) {
 
-        expect(Qs.parse('0=foo')).to.deep.equal({ '0': 'foo' }, { prototype: false });
-        expect(Qs.parse('foo=c++')).to.deep.equal({ foo: 'c  ' }, { prototype: false });
-        expect(Qs.parse('a[>=]=23')).to.deep.equal({ a: { '>=': '23' } }, { prototype: false });
-        expect(Qs.parse('a[<=>]==23')).to.deep.equal({ a: { '<=>': '=23' } }, { prototype: false });
-        expect(Qs.parse('a[==]=23')).to.deep.equal({ a: { '==': '23' } }, { prototype: false });
-        expect(Qs.parse('foo', {strictNullHandling: true})).to.deep.equal({ foo: null }, { prototype: false });
-        expect(Qs.parse('foo' )).to.deep.equal({ foo: '' }, { prototype: false });
-        expect(Qs.parse('foo=')).to.deep.equal({ foo: '' }, { prototype: false });
-        expect(Qs.parse('foo=bar')).to.deep.equal({ foo: 'bar' }, { prototype: false });
-        expect(Qs.parse(' foo = bar = baz ')).to.deep.equal({ ' foo ': ' bar = baz ' }, { prototype: false });
-        expect(Qs.parse('foo=bar=baz')).to.deep.equal({ foo: 'bar=baz' }, { prototype: false });
-        expect(Qs.parse('foo=bar&bar=baz')).to.deep.equal({ foo: 'bar', bar: 'baz' }, { prototype: false });
-        expect(Qs.parse('foo2=bar2&baz2=')).to.deep.equal({ foo2: 'bar2', baz2: '' }, { prototype: false });
-        expect(Qs.parse('foo=bar&baz', {strictNullHandling: true})).to.deep.equal({ foo: 'bar', baz: null }, { prototype: false });
-        expect(Qs.parse('foo=bar&baz')).to.deep.equal({ foo: 'bar', baz: '' }, { prototype: false });
+        expect(Qs.parse('0=foo')).to.deep.equal({ '0': 'foo' });
+        expect(Qs.parse('foo=c++')).to.deep.equal({ foo: 'c  ' });
+        expect(Qs.parse('a[>=]=23')).to.deep.equal({ a: { '>=': '23' } });
+        expect(Qs.parse('a[<=>]==23')).to.deep.equal({ a: { '<=>': '=23' } });
+        expect(Qs.parse('a[==]=23')).to.deep.equal({ a: { '==': '23' } });
+        expect(Qs.parse('foo', { strictNullHandling: true })).to.deep.equal({ foo: null });
+        expect(Qs.parse('foo' )).to.deep.equal({ foo: '' });
+        expect(Qs.parse('foo=')).to.deep.equal({ foo: '' });
+        expect(Qs.parse('foo=bar')).to.deep.equal({ foo: 'bar' });
+        expect(Qs.parse(' foo = bar = baz ')).to.deep.equal({ ' foo ': ' bar = baz ' });
+        expect(Qs.parse('foo=bar=baz')).to.deep.equal({ foo: 'bar=baz' });
+        expect(Qs.parse('foo=bar&bar=baz')).to.deep.equal({ foo: 'bar', bar: 'baz' });
+        expect(Qs.parse('foo2=bar2&baz2=')).to.deep.equal({ foo2: 'bar2', baz2: '' });
+        expect(Qs.parse('foo=bar&baz', { strictNullHandling: true })).to.deep.equal({ foo: 'bar', baz: null });
+        expect(Qs.parse('foo=bar&baz')).to.deep.equal({ foo: 'bar', baz: '' });
         expect(Qs.parse('cht=p3&chd=t:60,40&chs=250x100&chl=Hello|World')).to.deep.equal({
             cht: 'p3',
             chd: 't:60,40',
             chs: '250x100',
             chl: 'Hello|World'
-        }, { prototype: false });
+        });
         done();
     });
 
     it('allows disabling dot notation', function (done) {
 
-        expect(Qs.parse('a.b=c')).to.deep.equal({ a: { b: 'c' } }, { prototype: false });
-        expect(Qs.parse('a.b=c', { allowDots: false })).to.deep.equal({ 'a.b': 'c' }, { prototype: false });
+        expect(Qs.parse('a.b=c')).to.deep.equal({ a: { b: 'c' } });
+        expect(Qs.parse('a.b=c', { allowDots: false })).to.deep.equal({ 'a.b': 'c' });
         done();
     });
 
     it('parses a single nested string', function (done) {
 
-        expect(Qs.parse('a[b]=c')).to.deep.equal({ a: { b: 'c' } }, { prototype: false });
+        expect(Qs.parse('a[b]=c')).to.deep.equal({ a: { b: 'c' } });
         done();
     });
 
     it('parses a double nested string', function (done) {
 
-        expect(Qs.parse('a[b][c]=d')).to.deep.equal({ a: { b: { c: 'd' } } }, { prototype: false });
+        expect(Qs.parse('a[b][c]=d')).to.deep.equal({ a: { b: { c: 'd' } } });
         done();
     });
 
     it('defaults to a depth of 5', function (done) {
 
-        expect(Qs.parse('a[b][c][d][e][f][g][h]=i')).to.deep.equal({ a: { b: { c: { d: { e: { f: { '[g][h]': 'i' } } } } } } }, { prototype: false });
+        expect(Qs.parse('a[b][c][d][e][f][g][h]=i')).to.deep.equal({ a: { b: { c: { d: { e: { f: { '[g][h]': 'i' } } } } } } });
         done();
     });
 
     it('only parses one level when depth = 1', function (done) {
 
-        expect(Qs.parse('a[b][c]=d', { depth: 1 })).to.deep.equal({ a: { b: { '[c]': 'd' } } }, { prototype: false });
-        expect(Qs.parse('a[b][c][d]=e', { depth: 1 })).to.deep.equal({ a: { b: { '[c][d]': 'e' } } }, { prototype: false });
+        expect(Qs.parse('a[b][c]=d', { depth: 1 })).to.deep.equal({ a: { b: { '[c]': 'd' } } });
+        expect(Qs.parse('a[b][c][d]=e', { depth: 1 })).to.deep.equal({ a: { b: { '[c][d]': 'e' } } });
         done();
     });
 
     it('parses a simple array', function (done) {
 
-        expect(Qs.parse('a=b&a=c')).to.deep.equal({ a: ['b', 'c'] }, { prototype: false });
+        expect(Qs.parse('a=b&a=c')).to.deep.equal({ a: ['b', 'c'] });
         done();
     });
 
     it('parses an explicit array', function (done) {
 
-        expect(Qs.parse('a[]=b')).to.deep.equal({ a: ['b'] }, { prototype: false });
-        expect(Qs.parse('a[]=b&a[]=c')).to.deep.equal({ a: ['b', 'c'] }, { prototype: false });
-        expect(Qs.parse('a[]=b&a[]=c&a[]=d')).to.deep.equal({ a: ['b', 'c', 'd'] }, { prototype: false });
+        expect(Qs.parse('a[]=b')).to.deep.equal({ a: ['b'] });
+        expect(Qs.parse('a[]=b&a[]=c')).to.deep.equal({ a: ['b', 'c'] });
+        expect(Qs.parse('a[]=b&a[]=c&a[]=d')).to.deep.equal({ a: ['b', 'c', 'd'] });
         done();
     });
 
     it('parses a mix of simple and explicit arrays', function (done) {
 
-        expect(Qs.parse('a=b&a[]=c')).to.deep.equal({ a: ['b', 'c'] }, { prototype: false });
-        expect(Qs.parse('a[]=b&a=c')).to.deep.equal({ a: ['b', 'c'] }, { prototype: false });
-        expect(Qs.parse('a[0]=b&a=c')).to.deep.equal({ a: ['b', 'c'] }, { prototype: false });
-        expect(Qs.parse('a=b&a[0]=c')).to.deep.equal({ a: ['b', 'c'] }, { prototype: false });
-        expect(Qs.parse('a[1]=b&a=c')).to.deep.equal({ a: ['b', 'c'] }, { prototype: false });
-        expect(Qs.parse('a=b&a[1]=c')).to.deep.equal({ a: ['b', 'c'] }, { prototype: false });
+        expect(Qs.parse('a=b&a[]=c')).to.deep.equal({ a: ['b', 'c'] });
+        expect(Qs.parse('a[]=b&a=c')).to.deep.equal({ a: ['b', 'c'] });
+        expect(Qs.parse('a[0]=b&a=c')).to.deep.equal({ a: ['b', 'c'] });
+        expect(Qs.parse('a=b&a[0]=c')).to.deep.equal({ a: ['b', 'c'] });
+        expect(Qs.parse('a[1]=b&a=c')).to.deep.equal({ a: ['b', 'c'] });
+        expect(Qs.parse('a=b&a[1]=c')).to.deep.equal({ a: ['b', 'c'] });
         done();
     });
 
     it('parses a nested array', function (done) {
 
-        expect(Qs.parse('a[b][]=c&a[b][]=d')).to.deep.equal({ a: { b: ['c', 'd'] } }, { prototype: false });
-        expect(Qs.parse('a[>=]=25')).to.deep.equal({ a: { '>=': '25' } }, { prototype: false });
+        expect(Qs.parse('a[b][]=c&a[b][]=d')).to.deep.equal({ a: { b: ['c', 'd'] } });
+        expect(Qs.parse('a[>=]=25')).to.deep.equal({ a: { '>=': '25' } });
         done();
     });
 
     it('allows to specify array indices', function (done) {
 
-        expect(Qs.parse('a[1]=c&a[0]=b&a[2]=d')).to.deep.equal({ a: ['b', 'c', 'd'] }, { prototype: false });
-        expect(Qs.parse('a[1]=c&a[0]=b')).to.deep.equal({ a: ['b', 'c'] }, { prototype: false });
-        expect(Qs.parse('a[1]=c')).to.deep.equal({ a: ['c'] }, { prototype: false });
+        expect(Qs.parse('a[1]=c&a[0]=b&a[2]=d')).to.deep.equal({ a: ['b', 'c', 'd'] });
+        expect(Qs.parse('a[1]=c&a[0]=b')).to.deep.equal({ a: ['b', 'c'] });
+        expect(Qs.parse('a[1]=c')).to.deep.equal({ a: ['c'] });
         done();
     });
 
     it('limits specific array indices to 20', function (done) {
 
-        expect(Qs.parse('a[20]=a')).to.deep.equal({ a: ['a'] }, { prototype: false });
-        expect(Qs.parse('a[21]=a')).to.deep.equal({ a: { '21': 'a' } }, { prototype: false });
+        expect(Qs.parse('a[20]=a')).to.deep.equal({ a: ['a'] });
+        expect(Qs.parse('a[21]=a')).to.deep.equal({ a: { '21': 'a' } });
         done();
     });
 
     it('supports keys that begin with a number', function (done) {
 
-        expect(Qs.parse('a[12b]=c')).to.deep.equal({ a: { '12b': 'c' } }, { prototype: false });
+        expect(Qs.parse('a[12b]=c')).to.deep.equal({ a: { '12b': 'c' } });
         done();
     });
 
     it('supports encoded = signs', function (done) {
 
-        expect(Qs.parse('he%3Dllo=th%3Dere')).to.deep.equal({ 'he=llo': 'th=ere' }, { prototype: false });
+        expect(Qs.parse('he%3Dllo=th%3Dere')).to.deep.equal({ 'he=llo': 'th=ere' });
         done();
     });
 
     it('is ok with url encoded strings', function (done) {
 
-        expect(Qs.parse('a[b%20c]=d')).to.deep.equal({ a: { 'b c': 'd' } }, { prototype: false });
-        expect(Qs.parse('a[b]=c%20d')).to.deep.equal({ a: { b: 'c d' } }, { prototype: false });
+        expect(Qs.parse('a[b%20c]=d')).to.deep.equal({ a: { 'b c': 'd' } });
+        expect(Qs.parse('a[b]=c%20d')).to.deep.equal({ a: { b: 'c d' } });
         done();
     });
 
     it('allows brackets in the value', function (done) {
 
-        expect(Qs.parse('pets=["tobi"]')).to.deep.equal({ pets: '["tobi"]' }, { prototype: false });
-        expect(Qs.parse('operators=[">=", "<="]')).to.deep.equal({ operators: '[">=", "<="]' }, { prototype: false });
+        expect(Qs.parse('pets=["tobi"]')).to.deep.equal({ pets: '["tobi"]' });
+        expect(Qs.parse('operators=[">=", "<="]')).to.deep.equal({ operators: '[">=", "<="]' });
         done();
     });
 
     it('allows empty values', function (done) {
 
-        expect(Qs.parse('')).to.deep.equal({}, { prototype: false });
-        expect(Qs.parse(null)).to.deep.equal({}, { prototype: false });
-        expect(Qs.parse(undefined)).to.deep.equal({}, { prototype: false });
+        expect(Qs.parse('')).to.deep.equal({});
+        expect(Qs.parse(null)).to.deep.equal({});
+        expect(Qs.parse(undefined)).to.deep.equal({});
         done();
     });
 
     it('transforms arrays to objects', function (done) {
 
-        expect(Qs.parse('foo[0]=bar&foo[bad]=baz')).to.deep.equal({ foo: { '0': 'bar', bad: 'baz' } }, { prototype: false });
-        expect(Qs.parse('foo[bad]=baz&foo[0]=bar')).to.deep.equal({ foo: { bad: 'baz', '0': 'bar' } }, { prototype: false });
-        expect(Qs.parse('foo[bad]=baz&foo[]=bar')).to.deep.equal({ foo: { bad: 'baz', '0': 'bar' } }, { prototype: false });
-        expect(Qs.parse('foo[]=bar&foo[bad]=baz')).to.deep.equal({ foo: { '0': 'bar', bad: 'baz' } }, { prototype: false });
-        expect(Qs.parse('foo[bad]=baz&foo[]=bar&foo[]=foo')).to.deep.equal({ foo: { bad: 'baz', '0': 'bar', '1': 'foo' } }, { prototype: false });
-        expect(Qs.parse('foo[0][a]=a&foo[0][b]=b&foo[1][a]=aa&foo[1][b]=bb')).to.deep.equal({foo: [ {a: 'a', b: 'b'}, {a: 'aa', b: 'bb'} ]}, { prototype: false });
-        expect(Qs.parse('a[]=b&a[t]=u&a[hasOwnProperty]=c')).to.deep.equal({ a: { '0': 'b', t: 'u', hasOwnProperty: 'c' } }, { prototype: false });
-        expect(Qs.parse('a[]=b&a[hasOwnProperty]=c&a[x]=y')).to.deep.equal({ a: { '0': 'b', hasOwnProperty: 'c', x: 'y' } }, { prototype: false });
+        expect(Qs.parse('foo[0]=bar&foo[bad]=baz')).to.deep.equal({ foo: { '0': 'bar', bad: 'baz' } });
+        expect(Qs.parse('foo[bad]=baz&foo[0]=bar')).to.deep.equal({ foo: { bad: 'baz', '0': 'bar' } });
+        expect(Qs.parse('foo[bad]=baz&foo[]=bar')).to.deep.equal({ foo: { bad: 'baz', '0': 'bar' } });
+        expect(Qs.parse('foo[]=bar&foo[bad]=baz')).to.deep.equal({ foo: { '0': 'bar', bad: 'baz' } });
+        expect(Qs.parse('foo[bad]=baz&foo[]=bar&foo[]=foo')).to.deep.equal({ foo: { bad: 'baz', '0': 'bar', '1': 'foo' } });
+        expect(Qs.parse('foo[0][a]=a&foo[0][b]=b&foo[1][a]=aa&foo[1][b]=bb')).to.deep.equal({ foo: [{ a: 'a', b: 'b' }, { a: 'aa', b: 'bb' }] });
+        expect(Qs.parse('a[]=b&a[t]=u&a[hasOwnProperty]=c')).to.deep.equal({ a: { '0': 'b', t: 'u', c: true } });
+        expect(Qs.parse('a[]=b&a[hasOwnProperty]=c&a[x]=y')).to.deep.equal({ a: { '0': 'b', '1': 'c', x: 'y' } });
         done();
     });
 
     it('transforms arrays to objects (dot notation)', function (done) {
 
-        expect(Qs.parse('foo[0].baz=bar&fool.bad=baz')).to.deep.equal({ foo: [ { baz: 'bar'} ], fool: { bad: 'baz' } }, { prototype: false });
-        expect(Qs.parse('foo[0].baz=bar&fool.bad.boo=baz')).to.deep.equal({ foo: [ { baz: 'bar'} ], fool: { bad: { boo: 'baz' } } }, { prototype: false });
-        expect(Qs.parse('foo[0][0].baz=bar&fool.bad=baz')).to.deep.equal({ foo: [[ { baz: 'bar'} ]], fool: { bad: 'baz' } }, { prototype: false });
-        expect(Qs.parse('foo[0].baz[0]=15&foo[0].bar=2')).to.deep.equal({ foo: [{ baz: ['15'], bar: '2' }] }, { prototype: false });
-        expect(Qs.parse('foo[0].baz[0]=15&foo[0].baz[1]=16&foo[0].bar=2')).to.deep.equal({ foo: [{ baz: ['15', '16'], bar: '2' }] }, { prototype: false });
-        expect(Qs.parse('foo.bad=baz&foo[0]=bar')).to.deep.equal({ foo: { bad: 'baz', '0': 'bar' } }, { prototype: false });
-        expect(Qs.parse('foo.bad=baz&foo[]=bar')).to.deep.equal({ foo: { bad: 'baz', '0': 'bar' } }, { prototype: false });
-        expect(Qs.parse('foo[]=bar&foo.bad=baz')).to.deep.equal({ foo: { '0': 'bar', bad: 'baz' } }, { prototype: false });
-        expect(Qs.parse('foo.bad=baz&foo[]=bar&foo[]=foo')).to.deep.equal({ foo: { bad: 'baz', '0': 'bar', '1': 'foo' } }, { prototype: false });
-        expect(Qs.parse('foo[0].a=a&foo[0].b=b&foo[1].a=aa&foo[1].b=bb')).to.deep.equal({foo: [ {a: 'a', b: 'b'}, {a: 'aa', b: 'bb'} ]}, { prototype: false });
+        expect(Qs.parse('foo[0].baz=bar&fool.bad=baz')).to.deep.equal({ foo: [{ baz: 'bar' }], fool: { bad: 'baz' } });
+        expect(Qs.parse('foo[0].baz=bar&fool.bad.boo=baz')).to.deep.equal({ foo: [{ baz: 'bar' }], fool: { bad: { boo: 'baz' } } });
+        expect(Qs.parse('foo[0][0].baz=bar&fool.bad=baz')).to.deep.equal({ foo: [[{ baz: 'bar' }]], fool: { bad: 'baz' } });
+        expect(Qs.parse('foo[0].baz[0]=15&foo[0].bar=2')).to.deep.equal({ foo: [{ baz: ['15'], bar: '2' }] });
+        expect(Qs.parse('foo[0].baz[0]=15&foo[0].baz[1]=16&foo[0].bar=2')).to.deep.equal({ foo: [{ baz: ['15', '16'], bar: '2' }] });
+        expect(Qs.parse('foo.bad=baz&foo[0]=bar')).to.deep.equal({ foo: { bad: 'baz', '0': 'bar' } });
+        expect(Qs.parse('foo.bad=baz&foo[]=bar')).to.deep.equal({ foo: { bad: 'baz', '0': 'bar' } });
+        expect(Qs.parse('foo[]=bar&foo.bad=baz')).to.deep.equal({ foo: { '0': 'bar', bad: 'baz' } });
+        expect(Qs.parse('foo.bad=baz&foo[]=bar&foo[]=foo')).to.deep.equal({ foo: { bad: 'baz', '0': 'bar', '1': 'foo' } });
+        expect(Qs.parse('foo[0].a=a&foo[0].b=b&foo[1].a=aa&foo[1].b=bb')).to.deep.equal({ foo: [{ a: 'a', b: 'b' }, { a: 'aa', b: 'bb' }] });
         done();
     });
 
     it('can add keys to objects', function (done) {
 
-        expect(Qs.parse('a[b]=c&a=d')).to.deep.equal({ a: { b: 'c', d: true } }, { prototype: false });
+        expect(Qs.parse('a[b]=c&a=d')).to.deep.equal({ a: { b: 'c', d: true } });
         done();
     });
 
     it('correctly prunes undefined values when converting an array to an object', function (done) {
 
-        expect(Qs.parse('a[2]=b&a[99999999]=c')).to.deep.equal({ a: { '2': 'b', '99999999': 'c' } }, { prototype: false });
+        expect(Qs.parse('a[2]=b&a[99999999]=c')).to.deep.equal({ a: { '2': 'b', '99999999': 'c' } });
         done();
     });
 
     it('supports malformed uri characters', function (done) {
 
-        expect(Qs.parse('{%:%}', {strictNullHandling: true})).to.deep.equal({ '{%:%}': null }, { prototype: false });
-        expect(Qs.parse('{%:%}=')).to.deep.equal({ '{%:%}': '' }, { prototype: false });
-        expect(Qs.parse('foo=%:%}')).to.deep.equal({ foo: '%:%}' }, { prototype: false });
+        expect(Qs.parse('{%:%}', { strictNullHandling: true })).to.deep.equal({ '{%:%}': null });
+        expect(Qs.parse('{%:%}=')).to.deep.equal({ '{%:%}': '' });
+        expect(Qs.parse('foo=%:%}')).to.deep.equal({ foo: '%:%}' });
         done();
     });
 
     it('doesn\'t produce empty keys', function (done) {
 
-        expect(Qs.parse('_r=1&')).to.deep.equal({ '_r': '1' }, { prototype: false });
+        expect(Qs.parse('_r=1&')).to.deep.equal({ '_r': '1' });
         done();
     });
 
@@ -224,45 +224,45 @@ describe('parse()', function () {
 
     it('parses arrays of objects', function (done) {
 
-        expect(Qs.parse('a[][b]=c')).to.deep.equal({ a: [{ b: 'c' }] }, { prototype: false });
-        expect(Qs.parse('a[0][b]=c')).to.deep.equal({ a: [{ b: 'c' }] }, { prototype: false });
+        expect(Qs.parse('a[][b]=c')).to.deep.equal({ a: [{ b: 'c' }] });
+        expect(Qs.parse('a[0][b]=c')).to.deep.equal({ a: [{ b: 'c' }] });
         done();
     });
 
     it('allows for empty strings in arrays', function (done) {
 
-        expect(Qs.parse('a[]=b&a[]=&a[]=c')).to.deep.equal({ a: ['b', '', 'c'] }, { prototype: false });
-        expect(Qs.parse('a[0]=b&a[1]&a[2]=c&a[19]=', {strictNullHandling: true})).to.deep.equal({ a: ['b', null, 'c', ''] }, { prototype: false });
-        expect(Qs.parse('a[0]=b&a[1]=&a[2]=c&a[19]', {strictNullHandling: true})).to.deep.equal({ a: ['b', '', 'c', null] }, { prototype: false });
-        expect(Qs.parse('a[]=&a[]=b&a[]=c')).to.deep.equal({ a: ['', 'b', 'c'] }, { prototype: false });
+        expect(Qs.parse('a[]=b&a[]=&a[]=c')).to.deep.equal({ a: ['b', '', 'c'] });
+        expect(Qs.parse('a[0]=b&a[1]&a[2]=c&a[19]=', { strictNullHandling: true })).to.deep.equal({ a: ['b', null, 'c', ''] });
+        expect(Qs.parse('a[0]=b&a[1]=&a[2]=c&a[19]', { strictNullHandling: true })).to.deep.equal({ a: ['b', '', 'c', null] });
+        expect(Qs.parse('a[]=&a[]=b&a[]=c')).to.deep.equal({ a: ['', 'b', 'c'] });
         done();
     });
 
     it('compacts sparse arrays', function (done) {
 
-        expect(Qs.parse('a[10]=1&a[2]=2')).to.deep.equal({ a: ['2', '1'] }, { prototype: false });
+        expect(Qs.parse('a[10]=1&a[2]=2')).to.deep.equal({ a: ['2', '1'] });
         done();
     });
 
     it('parses semi-parsed strings', function (done) {
 
-        expect(Qs.parse({ 'a[b]': 'c' })).to.deep.equal({ a: { b: 'c' } }, { prototype: false });
-        expect(Qs.parse({ 'a[b]': 'c', 'a[d]': 'e' })).to.deep.equal({ a: { b: 'c', d: 'e' } }, { prototype: false });
+        expect(Qs.parse({ 'a[b]': 'c' })).to.deep.equal({ a: { b: 'c' } });
+        expect(Qs.parse({ 'a[b]': 'c', 'a[d]': 'e' })).to.deep.equal({ a: { b: 'c', d: 'e' } });
         done();
     });
 
     it('parses buffers correctly', function (done) {
 
         var b = new Buffer('test');
-        expect(Qs.parse({ a: b })).to.deep.equal({ a: b }, { prototype: false });
+        expect(Qs.parse({ a: b })).to.deep.equal({ a: b });
         done();
     });
 
     it('continues parsing when no parent is found', function (done) {
 
-        expect(Qs.parse('[]=&a=b')).to.deep.equal({ '0': '', a: 'b' }, { prototype: false });
-        expect(Qs.parse('[]&a=b', {strictNullHandling: true})).to.deep.equal({ '0': null, a: 'b' }, { prototype: false });
-        expect(Qs.parse('[foo]=bar')).to.deep.equal({ foo: 'bar' }, { prototype: false });
+        expect(Qs.parse('[]=&a=b')).to.deep.equal({ '0': '', a: 'b' });
+        expect(Qs.parse('[]&a=b', { strictNullHandling: true })).to.deep.equal({ '0': null, a: 'b' });
+        expect(Qs.parse('[foo]=bar')).to.deep.equal({ foo: 'bar' });
         done();
     });
 
@@ -286,9 +286,9 @@ describe('parse()', function () {
         Object.prototype.crash = '';
         Array.prototype.crash = '';
         expect(Qs.parse.bind(null, 'a=b')).to.not.throw();
-        expect(Qs.parse('a=b')).to.deep.equal({ a: 'b' }, { prototype: false });
+        expect(Qs.parse('a=b')).to.deep.equal({ a: 'b' });
         expect(Qs.parse.bind(null, 'a[][b]=c')).to.not.throw();
-        expect(Qs.parse('a[][b]=c')).to.deep.equal({ a: [{ b: 'c' }] }, { prototype: false });
+        expect(Qs.parse('a[][b]=c')).to.deep.equal({ a: [{ b: 'c' }] });
         delete Object.prototype.crash;
         delete Array.prototype.crash;
         done();
@@ -296,105 +296,105 @@ describe('parse()', function () {
 
     it('parses a string with an alternative string delimiter', function (done) {
 
-        expect(Qs.parse('a=b;c=d', { delimiter: ';' })).to.deep.equal({ a: 'b', c: 'd' }, { prototype: false });
+        expect(Qs.parse('a=b;c=d', { delimiter: ';' })).to.deep.equal({ a: 'b', c: 'd' });
         done();
     });
 
     it('parses a string with an alternative RegExp delimiter', function (done) {
 
-        expect(Qs.parse('a=b; c=d', { delimiter: /[;,] */ })).to.deep.equal({ a: 'b', c: 'd' }, { prototype: false });
+        expect(Qs.parse('a=b; c=d', { delimiter: /[;,] */ })).to.deep.equal({ a: 'b', c: 'd' });
         done();
     });
 
     it('does not use non-splittable objects as delimiters', function (done) {
 
-        expect(Qs.parse('a=b&c=d', { delimiter: true })).to.deep.equal({ a: 'b', c: 'd' }, { prototype: false });
+        expect(Qs.parse('a=b&c=d', { delimiter: true })).to.deep.equal({ a: 'b', c: 'd' });
         done();
     });
 
     it('allows overriding parameter limit', function (done) {
 
-        expect(Qs.parse('a=b&c=d', { parameterLimit: 1 })).to.deep.equal({ a: 'b' }, { prototype: false });
+        expect(Qs.parse('a=b&c=d', { parameterLimit: 1 })).to.deep.equal({ a: 'b' });
         done();
     });
 
     it('allows setting the parameter limit to Infinity', function (done) {
 
-        expect(Qs.parse('a=b&c=d', { parameterLimit: Infinity })).to.deep.equal({ a: 'b', c: 'd' }, { prototype: false });
+        expect(Qs.parse('a=b&c=d', { parameterLimit: Infinity })).to.deep.equal({ a: 'b', c: 'd' });
         done();
     });
 
     it('allows overriding array limit', function (done) {
 
-        expect(Qs.parse('a[0]=b', { arrayLimit: -1 })).to.deep.equal({ a: { '0': 'b' } }, { prototype: false });
-        expect(Qs.parse('a[-1]=b', { arrayLimit: -1 })).to.deep.equal({ a: { '-1': 'b' } }, { prototype: false });
-        expect(Qs.parse('a[0]=b&a[1]=c', { arrayLimit: 0 })).to.deep.equal({ a: { '0': 'b', '1': 'c' } }, { prototype: false });
+        expect(Qs.parse('a[0]=b', { arrayLimit: -1 })).to.deep.equal({ a: { '0': 'b' } });
+        expect(Qs.parse('a[-1]=b', { arrayLimit: -1 })).to.deep.equal({ a: { '-1': 'b' } });
+        expect(Qs.parse('a[0]=b&a[1]=c', { arrayLimit: 0 })).to.deep.equal({ a: { '0': 'b', '1': 'c' } });
         done();
     });
 
     it('allows disabling array parsing', function (done) {
 
-        expect(Qs.parse('a[0]=b&a[1]=c', { parseArrays: false })).to.deep.equal({ a: { '0': 'b', '1': 'c' } }, { prototype: false });
+        expect(Qs.parse('a[0]=b&a[1]=c', { parseArrays: false })).to.deep.equal({ a: { '0': 'b', '1': 'c' } });
         done();
     });
 
     it('parses an object', function (done) {
 
         var input = {
-            'user[name]': {'pop[bob]': 3},
+            'user[name]': { 'pop[bob]': 3 },
             'user[email]': null
         };
 
         var expected = {
             'user': {
-                'name': {'pop[bob]': 3},
+                'name': { 'pop[bob]': 3 },
                 'email': null
             }
         };
 
         var result = Qs.parse(input);
 
-        expect(result).to.deep.equal(expected, { prototype: false });
+        expect(result).to.deep.equal(expected);
         done();
     });
 
     it('parses an object in dot notation', function (done) {
 
         var input = {
-            'user.name': {'pop[bob]': 3},
+            'user.name': { 'pop[bob]': 3 },
             'user.email.': null
         };
 
         var expected = {
             'user': {
-                'name': {'pop[bob]': 3},
+                'name': { 'pop[bob]': 3 },
                 'email': null
             }
         };
 
         var result = Qs.parse(input);
 
-        expect(result).to.deep.equal(expected, { prototype: false });
+        expect(result).to.deep.equal(expected);
         done();
     });
 
     it('parses an object and not child values', function (done) {
 
         var input = {
-            'user[name]': {'pop[bob]': { 'test': 3 }},
+            'user[name]': { 'pop[bob]': { 'test': 3 } },
             'user[email]': null
         };
 
         var expected = {
             'user': {
-                'name': {'pop[bob]': { 'test': 3 }},
+                'name': { 'pop[bob]': { 'test': 3 } },
                 'email': null
             }
         };
 
         var result = Qs.parse(input);
 
-        expect(result).to.deep.equal(expected, { prototype: false });
+        expect(result).to.deep.equal(expected);
         done();
     });
 
@@ -404,7 +404,7 @@ describe('parse()', function () {
         delete global.Buffer;
         var result = Qs.parse('a=b&c=d');
         global.Buffer = tempBuffer;
-        expect(result).to.deep.equal({ a: 'b', c: 'd' }, { prototype: false });
+        expect(result).to.deep.equal({ a: 'b', c: 'd' });
         done();
     });
 
@@ -423,7 +423,7 @@ describe('parse()', function () {
         expect(parsed).to.contain('foo');
         expect(parsed.foo).to.contain('bar', 'baz');
         expect(parsed.foo.bar).to.equal('baz');
-        expect(parsed.foo.baz).to.deep.equal(a, { prototype: false });
+        expect(parsed.foo.baz).to.deep.equal(a);
         done();
     });
 
@@ -432,24 +432,47 @@ describe('parse()', function () {
         var a = Object.create(null);
         a.b = 'c';
 
-        expect(Qs.parse(a)).to.deep.equal({ b: 'c' }, { prototype: false });
+        expect(Qs.parse(a)).to.deep.equal({ b: 'c' });
         var result = Qs.parse({ a: a });
         expect(result).to.contain('a');
-        expect(result.a).to.deep.equal(a, { prototype: false });
+        expect(result.a).to.deep.equal(a);
         done();
     });
 
     it('parses dates correctly', function (done) {
 
         var now = new Date();
-        expect(Qs.parse({ a: now })).to.deep.equal({ a: now }, { prototype: false });
+        expect(Qs.parse({ a: now })).to.deep.equal({ a: now });
         done();
     });
 
     it('parses regular expressions correctly', function (done) {
 
         var re = /^test$/;
-        expect(Qs.parse({ a: re })).to.deep.equal({ a: re }, { prototype: false });
+        expect(Qs.parse({ a: re })).to.deep.equal({ a: re });
+        done();
+    });
+
+    it('can prefix prototype properties', function (done) {
+
+        expect(Qs.parse('a[hasOwnProperty]=b', { prefixPrototypes: true })).to.deep.equal({ a: { _hasOwnProperty: 'b' } });
+        expect(Qs.parse('hasOwnProperty=b', { prefixPrototypes: true })).to.deep.equal({ _hasOwnProperty: 'b' });
+        done();
+    });
+
+    it('can return plain objects', function (done) {
+
+        var expected = Object.create(null);
+        expected.a = Object.create(null);
+        expected.a.b = 'c';
+        expected.a.hasOwnProperty = 'd';
+        expect(Qs.parse('a[b]=c&a[hasOwnProperty]=d', { plainObjects: true })).to.deep.equal(expected);
+        expect(Qs.parse(null, { plainObjects: true })).to.deep.equal(Object.create(null));
+        var expectedArray = Object.create(null);
+        expectedArray.a = Object.create(null);
+        expectedArray.a['0'] = 'b';
+        expectedArray.a.c = 'd';
+        expect(Qs.parse('a[]=b&a[c]=d', { plainObjects: true })).to.deep.equal(expectedArray);
         done();
     });
 });

--- a/test/parse.js
+++ b/test/parse.js
@@ -453,10 +453,10 @@ describe('parse()', function () {
         done();
     });
 
-    it('can prefix prototype properties', function (done) {
+    it('can allow overwriting prototype properties', function (done) {
 
-        expect(Qs.parse('a[hasOwnProperty]=b', { prefixPrototypes: true })).to.deep.equal({ a: { _hasOwnProperty: 'b' } });
-        expect(Qs.parse('hasOwnProperty=b', { prefixPrototypes: true })).to.deep.equal({ _hasOwnProperty: 'b' });
+        expect(Qs.parse('a[hasOwnProperty]=b', { allowPrototypes: true })).to.deep.equal({ a: { hasOwnProperty: 'b' } }, { prototype: false });
+        expect(Qs.parse('hasOwnProperty=b', { allowPrototypes: true })).to.deep.equal({ hasOwnProperty: 'b' }, { prototype: false });
         done();
     });
 

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -111,14 +111,14 @@ describe('stringify()', function () {
     it('stringifies an empty value', function (done) {
 
         expect(Qs.stringify({ a: '' })).to.equal('a=');
-        expect(Qs.stringify({ a: null }, {strictNullHandling: true})).to.equal('a');
+        expect(Qs.stringify({ a: null }, { strictNullHandling: true })).to.equal('a');
 
         expect(Qs.stringify({ a: '', b: '' })).to.equal('a=&b=');
-        expect(Qs.stringify({ a: null, b: '' }, {strictNullHandling: true})).to.equal('a&b=');
+        expect(Qs.stringify({ a: null, b: '' }, { strictNullHandling: true })).to.equal('a&b=');
 
         expect(Qs.stringify({ a: { b: '' } })).to.equal('a%5Bb%5D=');
-        expect(Qs.stringify({ a: { b: null } }, {strictNullHandling: true})).to.equal('a%5Bb%5D');
-        expect(Qs.stringify({ a: { b: null } }, {strictNullHandling: false})).to.equal('a%5Bb%5D=');
+        expect(Qs.stringify({ a: { b: null } }, { strictNullHandling: true })).to.equal('a%5Bb%5D');
+        expect(Qs.stringify({ a: { b: null } }, { strictNullHandling: false })).to.equal('a%5Bb%5D=');
 
         done();
     });
@@ -155,8 +155,8 @@ describe('stringify()', function () {
 
         expect(Qs.stringify({ a: undefined })).to.equal('');
 
-        expect(Qs.stringify({ a: { b: undefined, c: null } }, {strictNullHandling: true})).to.equal('a%5Bc%5D');
-        expect(Qs.stringify({ a: { b: undefined, c: null } }, {strictNullHandling: false})).to.equal('a%5Bc%5D=');
+        expect(Qs.stringify({ a: { b: undefined, c: null } }, { strictNullHandling: true })).to.equal('a%5Bc%5D');
+        expect(Qs.stringify({ a: { b: undefined, c: null } }, { strictNullHandling: false })).to.equal('a%5Bc%5D=');
         expect(Qs.stringify({ a: { b: undefined, c: '' } })).to.equal('a%5Bc%5D=');
         done();
     });
@@ -184,7 +184,7 @@ describe('stringify()', function () {
     it('skips properties that are part of the object prototype', function (done) {
 
         Object.prototype.crash = 'test';
-        expect(Qs.stringify({ a: 'b'})).to.equal('a=b');
+        expect(Qs.stringify({ a: 'b' })).to.equal('a=b');
         expect(Qs.stringify({ a: { b: 'c' } })).to.equal('a%5Bb%5D=c');
         delete Object.prototype.crash;
         done();
@@ -224,8 +224,8 @@ describe('stringify()', function () {
     it('selects properties when filter=array', function (done) {
 
         expect(Qs.stringify({ a: 'b' }, { filter: ['a'] })).to.equal('a=b');
-        expect(Qs.stringify({ a: 1}, { filter: [] })).to.equal('');
-        expect(Qs.stringify({ a: { b: [1, 2, 3, 4], c: 'd' }, c: 'f' }, { filter: ['a', 'b', 0, 2]})).to.equal('a%5Bb%5D%5B0%5D=1&a%5Bb%5D%5B2%5D=3');
+        expect(Qs.stringify({ a: 1 }, { filter: [] })).to.equal('');
+        expect(Qs.stringify({ a: { b: [1, 2, 3, 4], c: 'd' }, c: 'f' }, { filter: ['a', 'b', 0, 2] })).to.equal('a%5Bb%5D%5B0%5D=1&a%5Bb%5D%5B2%5D=3');
         done();
 
     });


### PR DESCRIPTION
this is a short term solution before 5.0.0 which will change everything. Essentially the default behavior will match the 2.x releases, with the difference that you may set the `plainObjects` option to `true` to get the behavior from the 3.x releases.

If you don't want plain objects but also don't want to lose keys that would overwrite prototype properties, you can set the `prefixPrototypes` option to `true` and those keys will be prefixed with an underscore `'_'` and passed along. It's not perfect, but at least the keys aren't silently ignored.

Would appreciate your feedback on this one @hueniverse @dougwilson