### PR TITLE
include dist to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -16,4 +16,3 @@ config.json
 coverage.*
 lib-cov
 complexity.md
-dist


### PR DESCRIPTION
I use npm for AMD. qs is only library from my front-end deps which doesn't include dist in npm package.
