### PR TITLE
Add flag `skipNulls` to optionally skip null values in stringify

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,3 +315,10 @@ Qs.parse('a&b=', { strictNullHandling: true });
 // { a: null, b: '' }
 
 ```
+
+To completely skip rendering keys with `null` values, use the `skipNulls` flag:
+
+```javascript
+qs.stringify({ a: 'b', c: null}, { skipNulls: true })
+// 'a=b'
+```

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -21,12 +21,12 @@ var internals = {
             return prefix;
         }
     },
-    strictNullHandling: false
+    strictNullHandling: false,
+    skipNulls: false
 };
 
 
-internals.stringify = function (obj, prefix, generateArrayPrefix, strictNullHandling, filter) {
-
+internals.stringify = function (obj, prefix, generateArrayPrefix, strictNullHandling, skipNulls, filter) {
     if (typeof filter === 'function') {
         obj = filter(prefix, obj);
     }
@@ -53,13 +53,18 @@ internals.stringify = function (obj, prefix, generateArrayPrefix, strictNullHand
 
     var values = [];
 
-    if (typeof obj === 'undefined') {
+    if (typeof obj === 'undefined'
+      || typeof obj === null && skipNulls) {
         return values;
     }
 
     var objKeys = Array.isArray(filter) ? filter : Object.keys(obj);
     for (var i = 0, il = objKeys.length; i < il; ++i) {
         var key = objKeys[i];
+
+        if (skipNulls && obj[key] === null) {
+          continue;
+        }
 
         if (Array.isArray(obj)) {
             values = values.concat(internals.stringify(obj[key], generateArrayPrefix(prefix, key), generateArrayPrefix, strictNullHandling, filter));
@@ -78,6 +83,7 @@ module.exports = function (obj, options) {
     options = options || {};
     var delimiter = typeof options.delimiter === 'undefined' ? internals.delimiter : options.delimiter;
     var strictNullHandling = typeof options.strictNullHandling === 'boolean' ? options.strictNullHandling : internals.strictNullHandling;
+    var skipNulls = typeof options.skipNulls === 'boolean' ? options.skipNulls : internals.skipNulls;
     var objKeys;
     var filter;
     if (typeof options.filter === 'function') {
@@ -112,9 +118,15 @@ module.exports = function (obj, options) {
     if (!objKeys) {
         objKeys = Object.keys(obj);
     }
+
     for (var i = 0, il = objKeys.length; i < il; ++i) {
         var key = objKeys[i];
-        keys = keys.concat(internals.stringify(obj[key], key, generateArrayPrefix, strictNullHandling, filter));
+
+        if (skipNulls && obj[key] === null) {
+          continue;
+        }
+        
+        keys = keys.concat(internals.stringify(obj[key], key, generateArrayPrefix, strictNullHandling, skipNulls, filter));
     }
 
     return keys.join(delimiter);

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -47,6 +47,11 @@ describe('stringify()', function () {
         done();
     });
 
+    it('omits nulls when asked', function (done) {
+        expect(Qs.stringify({ a: 'b', c: null}, { skipNulls: true })).to.equal('a=b');
+        done();
+    });
+
     it('omits array indices when asked', function (done) {
 
         expect(Qs.stringify({ a: ['b', 'c', 'd'] }, { indices: false })).to.equal('a=b&a=c&a=d');

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -52,6 +52,12 @@ describe('stringify()', function () {
         done();
     });
 
+
+    it('omits nested nulls when asked', function (done) {
+        expect(Qs.stringify({a: { b: 'c', d: null} }, { skipNulls: true })).to.equal('a%5Bb%5D=c');
+        done();
+    });
+
     it('omits array indices when asked', function (done) {
 
         expect(Qs.stringify({ a: ['b', 'c', 'd'] }, { indices: false })).to.equal('a=b&a=c&a=d');


### PR DESCRIPTION
I was getting frustrated having `null` values in a query object and having to replace them all with `undefined` to get the query string to render the way I wanted. This should fix that problem, by adding a `skipNull` flag to `stringify`, which essentially makes null values act as if they were `undefined` for the purposes of stringifying.