### PR TITLE
Add an option to sort the keys in the query string FIX #64

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -27,7 +27,7 @@ var internals = {
 };
 
 
-internals.stringify = function (obj, prefix, generateArrayPrefix, strictNullHandling, skipNulls, encode, filter) {
+internals.stringify = function (obj, prefix, generateArrayPrefix, strictNullHandling, skipNulls, encode, filter, sort) {
 
     if (typeof filter === 'function') {
         obj = filter(prefix, obj);
@@ -62,7 +62,14 @@ internals.stringify = function (obj, prefix, generateArrayPrefix, strictNullHand
         return values;
     }
 
-    var objKeys = Array.isArray(filter) ? filter : Object.keys(obj);
+    var objKeys;
+    if (Array.isArray(filter)) {
+        objKeys = filter;
+    } else {
+        var keys = Object.keys(obj);
+        objKeys = sort ? keys.sort(sort) : keys;
+    }
+
     for (var i = 0, il = objKeys.length; i < il; ++i) {
         var key = objKeys[i];
 
@@ -91,6 +98,7 @@ module.exports = function (obj, options) {
     var strictNullHandling = typeof options.strictNullHandling === 'boolean' ? options.strictNullHandling : internals.strictNullHandling;
     var skipNulls = typeof options.skipNulls === 'boolean' ? options.skipNulls : internals.skipNulls;
     var encode = typeof options.encode === 'boolean' ? options.encode : internals.encode;
+    var sort = typeof options.sort === 'function' ? options.sort : null;
     var objKeys;
     var filter;
     if (typeof options.filter === 'function') {
@@ -126,6 +134,10 @@ module.exports = function (obj, options) {
         objKeys = Object.keys(obj);
     }
 
+    if (sort) {
+        objKeys.sort(sort);
+    }
+
     for (var i = 0, il = objKeys.length; i < il; ++i) {
         var key = objKeys[i];
 
@@ -135,7 +147,7 @@ module.exports = function (obj, options) {
             continue;
         }
 
-        keys = keys.concat(internals.stringify(obj[key], key, generateArrayPrefix, strictNullHandling, skipNulls, encode, filter));
+        keys = keys.concat(internals.stringify(obj[key], key, generateArrayPrefix, strictNullHandling, skipNulls, encode, filter, sort));
     }
 
     return keys.join(delimiter);

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -278,4 +278,16 @@ describe('stringify()', function () {
         expect(Qs.stringify({ a: 'b', c: null }, { strictNullHandling: true, encode: false })).to.equal('a=b&c');
         done();
     });
+
+    it('can sort the keys', function (done) {
+
+        var sort = function alphabeticalSort (a, b) {
+
+            return a.localeCompare(b);
+        };
+
+        expect(Qs.stringify({ a: 'c', z: 'y', b : 'f' }, { sort : sort })).to.equal('a=c&b=f&z=y');
+        expect(Qs.stringify({ a: 'c', z: { j: 'a', i:'b' }, b : 'f' }, { sort : sort })).to.equal('a=c&b=f&z%5Bi%5D=b&z%5Bj%5D=a');
+        done();
+    });
 });


### PR DESCRIPTION
This option is needed when we want to create predictable query strings.